### PR TITLE
Brian/perffixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,11 @@ See examples directory for more.
 Changelog
 =========
 
+0.23.0-PMX Fork
+---
+* Re-using the same socket as the listener for sending all outbound multicast traffic to avoid having respond_only sockets that build up Recv-Q that don't get serviced
+* Disabled the short circuit of the servicebrowser delay when it has records that have gone stale
+
 0.23.0
 ------
 

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -2456,7 +2456,7 @@ class Zeroconf(QuietLogger):
             out.id = msg.id
             self.send(out, addr, port)
 
-    def send_via_configured_socket(self, s, out: DNSOutgoing, addr: Optional[str] = None, port: int = _MDNS_PORT) -> None:
+    def send_via_configured_socket(self, s, packet, addr: Optional[str] = None, port: int = _MDNS_PORT) -> None:
         try:
             if addr is None:
                 real_addr = _MDNS_ADDR6 if s.family == socket.AF_INET6 else _MDNS_ADDR
@@ -2494,12 +2494,12 @@ class Zeroconf(QuietLogger):
             s.setsockopt(so["IPProto"],so["SocketOpt"],so["SocketOptValue"])
             if self._GLOBAL_DONE:
                 return
-            self.send_via_configured_socket(s,out,addr,port)
+            self.send_via_configured_socket(s,packet,addr,port)
 
         for so in self._respond_sockets:
             if self._GLOBAL_DONE:
                 return
-            self.send_via_configured_socket(s,out,addr,port)
+            self.send_via_configured_socket(s,packet,addr,port)
 
 
 


### PR DESCRIPTION
The overall goal for this fix is to allow us to turn down the chatty behavior of the zeroconf library. When installed on many python nodes on a docker host for instance, there is a traffic multiplication event which causes the nodes to spend a lot of time processing redundant mdns traffic information.

* Consolidated the system to use a single socket for all mdns communication.  The dedicated "respond" sockets were not servicing the recv-q and those were filling up potentially causing the kernel to have to deal with filled buffers.
* Removed the feature that was overwriting the delay setting for the service browser so that we can extend the delay to 10+ seconds between service queries.
* Disabled the short-circuit of the servicebrower delay by any service that has expired.

Future work
========
* Have the library short circuit the response to queries if another node has already responded per the RFC.
* Validate that the logic to remove the registration of services owned by the process works given lots of termination paths.