### PR TITLE
Increase the Max Msg Size expected

### DIFF
--- a/zeroconf.py
+++ b/zeroconf.py
@@ -91,7 +91,7 @@ _DNS_HOST_TTL = 120  # two minute for host records (A, SRV etc) as-per RFC6762
 _DNS_OTHER_TTL = 4500  # 75 minutes for non-host records (PTR, TXT etc) as-per RFC6762
 
 _MAX_MSG_TYPICAL = 1460  # unused
-_MAX_MSG_ABSOLUTE = 8966
+_MAX_MSG_ABSOLUTE = 17932
 
 _FLAGS_QR_MASK = 0x8000  # query response mask
 _FLAGS_QR_QUERY = 0x0000  # query


### PR DESCRIPTION
This increases the size of the max message execpted by zeroconf.  The DNS-SD standard says the field can be as large as 65535 bytes in size.  It is not clear why the zeroconf library does not come configured for the max possible size, so we are simply doubling it for now.

This was tested by running our axon application in a scenario where large announcements were flowing. Verifying it would truncate announcements. Increased the size. Could no longer reproduce the error.  